### PR TITLE
fix on invalid label patterns.

### DIFF
--- a/lib/reredos.rb
+++ b/lib/reredos.rb
@@ -20,7 +20,7 @@ module Reredos
 
     def valid_domain?(str)
       return false if str.length > DOMAIN_MAX_LENGTH
-      return false unless str.split('.').all? { |_| valid_label?(_) }
+      return false unless str.split('.').all? { |l| valid_label?(l) }
 
       true
     end
@@ -37,7 +37,7 @@ module Reredos
       return false unless letter?(str[0])
       return false unless alphanumeric?(str[-1])
       return true if str[1...-1].empty?
-      return str[1...-1].chars.all? { |_| hyphen_or_alphanumeric?(_) }
+      return str[1...-1].chars.all? { |c| hyphen_or_alphanumeric?(c) }
     end
 
     def letter?(char)

--- a/lib/reredos.rb
+++ b/lib/reredos.rb
@@ -20,10 +20,7 @@ module Reredos
 
     def valid_domain?(str)
       return false if str.length > DOMAIN_MAX_LENGTH
-
-      labels = str.split('.')
-      return false if labels.map(&:length).any?{ |_| _ > DOMAIN_LABEL_MAX_LENGTH }
-      return false unless labels.all? { |_| valid_label?(_) }
+      return false unless str.split('.').all? { |_| valid_label?(_) }
 
       true
     end
@@ -36,6 +33,7 @@ module Reredos
     # ラベルはアルファベットで始まり、アルファベットか数字かハイフンが続き、アルファベットか数字で終わる
     def valid_label?(str)
       return false if str.empty?
+      return false if str.length > DOMAIN_LABEL_MAX_LENGTH
       return false unless letter?(str[0])
       return false unless alphanumeric?(str[-1])
       return true if str[1...-1].empty?

--- a/lib/reredos.rb
+++ b/lib/reredos.rb
@@ -20,7 +20,6 @@ module Reredos
 
     def valid_domain?(str)
       return false if str.length > DOMAIN_MAX_LENGTH
-      return false if str[-1] == '-' # 末尾は-でない
 
       labels = str.split('.')
       return false if labels.map(&:length).any?{ |_| _ > DOMAIN_LABEL_MAX_LENGTH }

--- a/lib/reredos.rb
+++ b/lib/reredos.rb
@@ -37,7 +37,8 @@ module Reredos
       return false unless letter?(str[0])
       return false unless alphanumeric?(str[-1])
       return true if str[1...-1].empty?
-      return str[1...-1].chars.all? { |c| hyphen_or_alphanumeric?(c) }
+
+      str[1...-1].chars.all? { |c| hyphen_or_alphanumeric?(c) }
     end
 
     def letter?(char)

--- a/lib/reredos.rb
+++ b/lib/reredos.rb
@@ -24,7 +24,7 @@ module Reredos
 
       labels = str.split('.')
       return false if labels.map(&:length).any?{ |_| _ > DOMAIN_LABEL_MAX_LENGTH }
-      return false unless labels.map{ |_| /\A[0-9a-zA-Z\-]+\z/ === _ }.all? # ラベルに含まれる文字が1文字以上の英数字orハイフン
+      return false unless labels.all? { |_| valid_label?(_) }
 
       true
     end
@@ -32,6 +32,31 @@ module Reredos
     def valid_username?(str)
       return false if str.length > USERNAME_MAX_LENGTH
       /\A[0-9a-zA-Z\.\+\-\_]+\z/ === str # 既定の文字のみで構成されている
+    end
+
+    # ラベルはアルファベットで始まり、アルファベットか数字かハイフンが続き、アルファベットか数字で終わる
+    def valid_label?(str)
+      return false if str.length == 0
+      return false unless letter?(str[0])
+      return false unless alphanumeric?(str[-1])
+      return true if str[1...-1].empty?
+      return str[1...-1].chars.all? { |_| hyphen_or_alphanumeric?(_) }
+    end
+
+    def letter?(char)
+      ('a'..'z').include?(char) || ('A'..'Z').include?(char)
+    end
+
+    def digit?(char)
+      ('0'..'9').include?(char)
+    end
+
+    def alphanumeric?(char)
+      letter?(char) || digit?(char)
+    end
+
+    def hyphen_or_alphanumeric?(char)
+      char == '-' || alphanumeric?(char)
     end
   end
 end

--- a/lib/reredos.rb
+++ b/lib/reredos.rb
@@ -36,7 +36,7 @@ module Reredos
 
     # ラベルはアルファベットで始まり、アルファベットか数字かハイフンが続き、アルファベットか数字で終わる
     def valid_label?(str)
-      return false if str.length == 0
+      return false if str.empty?
       return false unless letter?(str[0])
       return false unless alphanumeric?(str[-1])
       return true if str[1...-1].empty?

--- a/spec/reredos_spec.rb
+++ b/spec/reredos_spec.rb
@@ -91,12 +91,6 @@ RSpec.describe Reredos do
           expect(Reredos.valid_email?(email)).to be_falsy
         end
       end
-      context 'only hypen label' do
-        let(:email){ 'user@example.-.com' }
-        it 'reject what has only hyphen label' do
-          expect(Reredos.valid_email?(email)).to be_falsy
-        end
-      end
       context 'starting with numeric' do
         let(:email){ 'user@example.0abc.com' }
         it 'reject what has label that starts with numeric' do

--- a/spec/reredos_spec.rb
+++ b/spec/reredos_spec.rb
@@ -91,6 +91,30 @@ RSpec.describe Reredos do
           expect(Reredos.valid_email?(email)).to be_falsy
         end
       end
+      context 'only hypen label' do
+        let(:email){ 'user@example.-.com' }
+        it 'reject what has only hyphen label' do
+          expect(Reredos.valid_email?(email)).to be_falsy
+        end
+      end
+      context 'starting with numeric' do
+        let(:email){ 'user@example.0abc.com' }
+        it 'reject what has label that starts with numeric' do
+          expect(Reredos.valid_email?(email)).to be_falsy
+        end
+      end
+      context 'ending with hypyen' do
+        let(:email){ 'user@example.abc-.com' }
+        it 'reject what has label that ends with hyphen' do
+          expect(Reredos.valid_email?(email)).to be_falsy
+        end
+      end
+      context 'single letter label' do
+        let(:email){ 'user@example.a.com' }
+        it 'accept what has single letter label' do
+          expect(Reredos.valid_email?(email)).to be_truthy
+        end
+      end
     end
 
     describe 'TLD' do


### PR DESCRIPTION
`Reredos.valid_email?` with some invalid label patterns returns true.

label must start with alphabet.
label must end with alphabet or digit.
label must be structured with alphabets and digits and hyphens.

> \<label\> ::= \<letter\> [ [ \<ldh-str\> ] \<let-dig\> ]
> \<ldh-str\> ::= \<let-dig-hyp\> | \<let-dig-hyp\> \<ldh-str\>
> \<let-dig-hyp\> ::= \<let-dig\> | "-"
> \<let-dig\> ::= \<letter\> | \<digit\>
> \<letter\> ::= any one of the 52 alphabetic characters A through Z in upper case and a through z in lower case
> \<digit\> ::= any one of the ten digits 0 through 9

From IRC1035
